### PR TITLE
add hqme flag, fetch entry & signer endpoints

### DIFF
--- a/src/downloadEntries.js
+++ b/src/downloadEntries.js
@@ -7,7 +7,7 @@ const createId = (string) => {
   return string.replace(/\s/g, "-").concat(`-${increment}`);
 };
 
-const createEntry = ({ title, summary, src }) => ({
+const createEntry = ({ title, summary, src, hqme = true }) => ({
   id: createId(title),
   title,
   summary,
@@ -20,6 +20,9 @@ const createEntry = ({ title, summary, src }) => ({
   }),
   content: {
     src,
+  },
+  extensions: {
+    hqme,
   },
 });
 
@@ -71,6 +74,13 @@ const BlipBlopm3u8 = createEntry({
   src: "https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8",
 });
 
+const undownloadableEntry = createEntry({
+  hqme: false,
+  title: "Can't download",
+  summary: "This is a video, but it cannot be downloaded",
+  src: "https://multiplatform-f.akamaihd.net/i/multi/will/bunny/big_buck_bunny_,640x360_400,640x360_700,640x360_1000,950x540_1500,.f4v.csmil/master.m3u8",
+});
+
 module.exports = {
   all: [
     bigBuckBunnyMp4,
@@ -81,7 +91,20 @@ module.exports = {
     bigbuckbunnym3u8,
     sintelm3u8,
     BlipBlopm3u8,
+    undownloadableEntry,
   ],
-  mp4: [bigBuckBunnyMp4, JellyFishMp4, SintelMp4, bigBuckBunnyMp4],
-  m3u8: [tearsOfSteelM3u8, bigbuckbunnym3u8, sintelm3u8, BlipBlopm3u8],
+  mp4: [
+    bigBuckBunnyMp4,
+    JellyFishMp4,
+    SintelMp4,
+    bigBuckBunnyMp4,
+    undownloadableEntry,
+  ],
+  m3u8: [
+    tearsOfSteelM3u8,
+    bigbuckbunnym3u8,
+    sintelm3u8,
+    BlipBlopm3u8,
+    undownloadableEntry,
+  ],
 };

--- a/src/routes.js
+++ b/src/routes.js
@@ -833,7 +833,7 @@ module.exports.setup = (app) => {
     const feedEntries = entries[type] || entries.all;
 
     const entry = testPreload
-      ? createEntriesWithoutStream(feedEntries, req)
+      ? createEntriesWithoutStream(feedEntries)
       : feedEntries;
 
     res.json({

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,4 @@
+const { uniqueId } = require("lodash");
 const path = require("path");
 
 const absoluteReqBasePath = process.env.BASE_URL || "http://localhost:3000/";
@@ -56,7 +57,34 @@ const renderChannelMediaGroupById = (id) => {
   };
 };
 
+const wrapEntryInFeed = (entry) => {
+  return {
+    id: uniqueId(),
+    type: { value: "feed" },
+    entry: [entry],
+  };
+};
+
+const createEntriesWithoutStream = (entries) => {
+  return entries.reduce((all, entry) => {
+    const entryWithoutStream = Object.assign({}, entry);
+
+    delete entryWithoutStream.content;
+
+    entryWithoutStream.link = {
+      rel: "self",
+      href: `${absoluteReqBasePath}stream/${entry.id}`,
+    };
+
+    all.push(entryWithoutStream);
+
+    return all;
+  }, []);
+};
+
 module.exports.absoluteReqPath = absoluteReqPath;
 module.exports.absoluteReqBasePath = absoluteReqBasePath;
 module.exports.renderDummyMediaGroup = renderDummyMediaGroup;
 module.exports.renderChannelMediaGroupById = renderChannelMediaGroupById;
+module.exports.wrapEntryInFeed = wrapEntryInFeed;
+module.exports.createEntriesWithoutStream = createEntriesWithoutStream;

--- a/src/utils.js
+++ b/src/utils.js
@@ -82,9 +82,22 @@ const createEntriesWithoutStream = (entries) => {
   }, []);
 };
 
+const responseForOutcome = (outcome) => {
+  return (
+    {
+      unauthorized: 403,
+      error: 500,
+      notFound: 404,
+      unprocessableEntity: 422,
+      success: 200,
+    }[outcome] || 200
+  );
+};
+
 module.exports.absoluteReqPath = absoluteReqPath;
 module.exports.absoluteReqBasePath = absoluteReqBasePath;
 module.exports.renderDummyMediaGroup = renderDummyMediaGroup;
 module.exports.renderChannelMediaGroupById = renderChannelMediaGroupById;
 module.exports.wrapEntryInFeed = wrapEntryInFeed;
 module.exports.createEntriesWithoutStream = createEntriesWithoutStream;
+module.exports.responseForOutcome = responseForOutcome;


### PR DESCRIPTION
This PR adds the hqme flag on downloadable items.

it also adds an option on the downloads feed to return entries without content.src but with link.href so we can test the video preloader. There is also a new endpoint to test the video signer API.