### PR TITLE
add resume watching endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+resume-watching.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -611,9 +611,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -1025,9 +1025,9 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "dev": true
     },
     "object-assign": {
@@ -1513,9 +1513,9 @@
       }
     },
     "urijs": {
-      "version": "1.19.6",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.6.tgz",
-      "integrity": "sha512-eSXsXZ2jLvGWeLYlQA3Gh36BcjF+0amo92+wHPyN1mdR8Nxf75fuEuYTd9c0a+m/vhCjRK0ESlE9YNLW+E1VEw=="
+      "version": "1.19.7",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.7.tgz",
+      "integrity": "sha512-Id+IKjdU0Hx+7Zx717jwLPsPeUqz7rAtuVBRLLs+qn+J2nf9NGITWVCxcijgYxBqe83C7sqsQPs6H1pyz3x9gA=="
     },
     "url-parse-lax": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "base64url": "^3.0.1",
+    "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "fuse.js": "^6.4.6",
@@ -21,7 +22,7 @@
     "swagger-jsdoc": "^6.0.1",
     "swagger-ui-dist": "^3.40.0",
     "swagger-ui-express": "^4.1.6",
-    "urijs": "^1.19.6"
+    "urijs": "^1.19.7"
   },
   "devDependencies": {
     "nodemon": "^2.0.7"

--- a/src/routes.js
+++ b/src/routes.js
@@ -1009,6 +1009,8 @@ module.exports.setup = (app) => {
 
     res.json(
       {
+        id: "resume-watching-full",
+        type: { value: 'feed' },
         entry: _.intersectionBy(items, eventIds, 'id').map((item) => {
           return entryRenderers[item.type](item);
         }),

--- a/src/routes.js
+++ b/src/routes.js
@@ -959,7 +959,7 @@ module.exports.setup = (app) => {
 
   })
 
-  app.get("/cloud-events", async (req, res) => {
+  app.get("/resume-watching", async (req, res) => {
     const { userId } = req.query;
     db.read();
     const events = db.get('events')


### PR DESCRIPTION
Add resume watching endpoints:

`/cloud-events` to POST stopped video event

`/resume-watching` to get List of video ids that the user started but didn't finish watching

`/resume-watching-full` get the full video list of videos that the user started and didn't finish

The GET endpoints require the `userId` query param that can be mapped using context keys