### PR TITLE
Add live streams

### DIFF
--- a/src/downloadEntries.js
+++ b/src/downloadEntries.js
@@ -1,11 +1,6 @@
-let increment = 0;
+const { renderDummyMediaGroup, createIdFactory } = require("./utils");
 
-const { renderDummyMediaGroup } = require("./utils");
-
-const createId = (string) => {
-  increment++;
-  return string.replace(/\s/g, "-").concat(`-${increment}`);
-};
+const createId = createIdFactory();
 
 const createEntry = ({ title, summary, src, hqme = true }) => ({
   id: createId(title),

--- a/src/live.js
+++ b/src/live.js
@@ -1,0 +1,45 @@
+const { renderDummyMediaGroup, createIdFactory } = require("./utils");
+
+const createId = createIdFactory();
+
+const createLiveEntry = ({ title, summary, src, liveFlag, type = "video" }) => {
+  const id = createId(title);
+
+  return {
+    id,
+    summary,
+    type: { value: type },
+    media_group: renderDummyMediaGroup({ id, title, summary, src }),
+    content: { src },
+    extensions: liveFlag ? { live: true } : {},
+  };
+};
+
+const getLiveFeed = (options) => {
+  const { liveFlag, type } = options || {};
+
+  return {
+    id: "live-streams-1",
+    title: "live",
+    summary: "These are test live streams",
+    type: { value: "feed" },
+    entry: [
+      createLiveEntry({
+        title: "Live 1",
+        summary: "Live stream with cinema aspect ration",
+        src: "https://cph-p2p-msl.akamaized.net/hls/live/2000341/test/master.m3u8",
+        liveFlag,
+        type,
+      }),
+      createLiveEntry({
+        title: "Live 2",
+        summary: "16:9 aspect ratio live stream",
+        src: "https://moctobpltc-i.akamaihd.net/hls/live/571329/eight/playlist.m3u8",
+        liveFlag,
+        type,
+      }),
+    ],
+  };
+};
+
+module.exports = getLiveFeed;

--- a/src/routes.js
+++ b/src/routes.js
@@ -10,20 +10,19 @@ const _ = require("lodash");
 const base64url = require("base64url");
 const { DateTime } = require("luxon");
 const URI = require("urijs");
-const bodyParser = require('body-parser')
-const jsonParser = bodyParser.json()
+const bodyParser = require("body-parser");
+const jsonParser = bodyParser.json();
 const mockDb = require("./mock-db");
-const { miscFeeds } = require('./misc-feeds')
-
-
+const { miscFeeds } = require("./misc-feeds");
 
 const low = require("lowdb");
-const FileSync = require('lowdb/adapters/FileSync')
+const FileSync = require("lowdb/adapters/FileSync");
+const getLiveFeed = require("./live");
 
-const adapter = new FileSync("resume-watching.json", { defaultValue: { events: [] }, });
-const db = low(adapter)
-
-
+const adapter = new FileSync("resume-watching.json", {
+  defaultValue: { events: [] },
+});
+const db = low(adapter);
 
 const SCREEN_TYPES = {
   EXAMPLE_EPISODE: "example-episode",
@@ -943,12 +942,11 @@ module.exports.setup = (app) => {
     res.json({ error: new Error(outcome).message });
   });
 
-
   app.post("/cloud-events", jsonParser, async (req, res) => {
     try {
-      if (req.body.type === 'com.applicaster.video.stopped.v1') {
+      if (req.body.type === "com.applicaster.video.stopped.v1") {
         db.read();
-        await db.get('events').push(req.body).write()
+        await db.get("events").push(req.body).write();
 
         res.status(201).end();
       }
@@ -957,71 +955,110 @@ module.exports.setup = (app) => {
 
       res.status(500).end();
     }
-
-  })
+  });
 
   app.get("/resume-watching", async (req, res) => {
     const { userId } = req.query;
     db.read();
-    const events = db.get('events')
+    const events = db
+      .get("events")
       .filter((event) => {
         try {
-          return event.data.userIdentifier === userId
+          return event.data.userIdentifier === userId;
         } catch (error) {
-          return false
+          return false;
         }
-      }).orderBy(['time'], ['desc'])
-      .uniqBy('data.videoId')
+      })
+      .orderBy(["time"], ["desc"])
+      .uniqBy("data.videoId")
       .take(30);
 
     res.json({
-      entry: events.map(event => ({
+      entry: events.map((event) => ({
         id: event.data.videoId,
         extensions: {
           resumeLastUpdate: event.time,
           resumeTime: event.data.secondsFromStart,
           progress: event.data.progress,
-          resumeCompleted: event.data.status === 'COMPLETED' ? true : undefined
-        }
-      }))
-    })
-  })
+          resumeCompleted: event.data.status === "COMPLETED" ? true : undefined,
+        },
+      })),
+    });
+  });
 
   app.get("/resume-watching-full", async (req, res) => {
     const { userId } = req.query;
     db.read();
-    const events = db.get('events')
+    const events = db
+      .get("events")
       .filter((event) => {
         try {
-          return event.data.userIdentifier === userId
+          return event.data.userIdentifier === userId;
         } catch (error) {
-          return false
+          return false;
         }
-      }).orderBy(['time'], ['desc'])
-      .uniqBy('data.videoId')
+      })
+      .orderBy(["time"], ["desc"])
+      .uniqBy("data.videoId")
       .take(30);
 
     const { items, nextPage } = mockDb.getMediaItems({
       filters: {},
       sorts: [],
-      perPage: 5000
+      perPage: 5000,
     });
 
-    const eventIds = events.map((event) => ({ id: event.data.videoId })).value();
+    const eventIds = events
+      .map((event) => ({ id: event.data.videoId }))
+      .value();
 
-    res.json(
-      {
-        id: "resume-watching-full",
-        type: { value: 'feed' },
-        entry: _.intersectionBy(items, eventIds, 'id').map((item) => {
-          return entryRenderers[item.type](item);
-        }),
-      }
-    )
-
-  })
+    res.json({
+      id: "resume-watching-full",
+      type: { value: "feed" },
+      entry: _.intersectionBy(items, eventIds, "id").map((item) => {
+        return entryRenderers[item.type](item);
+      }),
+    });
+  });
 
   app.get("/misc/:feedName", async (req, res) => {
-    res.json(miscFeeds[req.params.feedName]())
-  })
+    res.json(miscFeeds[req.params.feedName]());
+  });
+
+  // This endpoint will return a feed with live streams
+  /**
+   * @swagger
+   * /live
+   *   get:
+   *     description: |
+   *        returns a stream of live items
+   *
+   *     parameters:
+   *       - in: query
+   *         name: live_extension
+   *         description: |
+   *            adds live: true to the entries extensions
+   *         schema:
+   *           type: "number"
+   *       - in: query
+   *         name: type
+   *         description: |
+   *            sets the type for the entries. default is "video"
+   *         schema:
+   *           type: "string"
+   *
+   *     responses:
+   *       200:
+   *         description: Success
+   *
+   */
+  app.get("/live", async (req, res) => {
+    res.setHeader("content-type", "application/vnd+applicaster.pipes2+json");
+    res.setHeader("Cache-Control", "public, max-age=300");
+    res.setHeader("Access-Control-Allow-Origin", "*");
+
+    const { live_extension, type = undefined } = req.query;
+
+    res.json(getLiveFeed({ liveFlag: live_extension, type }));
+  });
 };

--- a/src/routes.js
+++ b/src/routes.js
@@ -1028,7 +1028,7 @@ module.exports.setup = (app) => {
   // This endpoint will return a feed with live streams
   /**
    * @swagger
-   * /live
+   * /live:
    *   get:
    *     description: |
    *        returns a stream of live items

--- a/src/utils.js
+++ b/src/utils.js
@@ -94,6 +94,15 @@ const responseForOutcome = (outcome) => {
   );
 };
 
+const createIdFactory = () => {
+  let increment = 0;
+
+  return (string) => {
+    increment++;
+    return string.replace(/\s/g, "-").concat(`-${increment}`);
+  };
+};
+
 module.exports.absoluteReqPath = absoluteReqPath;
 module.exports.absoluteReqBasePath = absoluteReqBasePath;
 module.exports.renderDummyMediaGroup = renderDummyMediaGroup;
@@ -101,3 +110,4 @@ module.exports.renderChannelMediaGroupById = renderChannelMediaGroupById;
 module.exports.wrapEntryInFeed = wrapEntryInFeed;
 module.exports.createEntriesWithoutStream = createEntriesWithoutStream;
 module.exports.responseForOutcome = responseForOutcome;
+module.exports.createIdFactory = createIdFactory;


### PR DESCRIPTION
This PR adds a live stream feed for the example app's back end

2 live feeds in it.

feed is /live

available options:
- add `{ live: true}` in the entries' extensions `/live?live_extension=true`
- change the type of the entries (default is "video"): `/live?type=channel`

