### PR TITLE
fix: handle timeouts in random image generator for EPG

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,8 @@
         "titleBar.inactiveForeground": "#15202b99",
         "sash.hoverBorder": "#74e9da",
         "statusBarItem.remoteBackground": "#48e2ce",
-        "statusBarItem.remoteForeground": "#15202b"
+        "statusBarItem.remoteForeground": "#15202b",
+        "commandCenter.border": "#15202b99"
     },
     "peacock.color": "#48e2ce"
 }


### PR DESCRIPTION
This PR fixes the random image generator for EPG.
it was timing out in some scenarios, causing the request to hang and cause an unhandled promise rejection, killing the server